### PR TITLE
Added tags for breed/tame items.

### DIFF
--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
@@ -1,7 +1,10 @@
 package com.cgessinger.creaturesandbeasts.entities;
 
 import com.cgessinger.creaturesandbeasts.containers.CinderFurnaceContainer;
-import com.cgessinger.creaturesandbeasts.init.*;
+import com.cgessinger.creaturesandbeasts.init.CNBBlocks;
+import com.cgessinger.creaturesandbeasts.init.CNBEntityTypes;
+import com.cgessinger.creaturesandbeasts.init.CNBItems;
+import com.cgessinger.creaturesandbeasts.init.CNBSoundEvents;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;

--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
@@ -95,13 +95,14 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 
+import static com.cgessinger.creaturesandbeasts.init.CNBTags.Items.CINDERSHELL_FOOD;
+
 public class CindershellEntity extends Animal implements IAnimatable, Bucketable, ContainerListener, Container, RecipeHolder, StackedContentsCompatible, MenuProvider {
     private static final EntityDataAccessor<Boolean> EATING = SynchedEntityData.defineId(CindershellEntity.class, EntityDataSerializers.BOOLEAN);
     private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(CindershellEntity.class, EntityDataSerializers.BOOLEAN);
     private static final EntityDataAccessor<Boolean> FURNACE = SynchedEntityData.defineId(CindershellEntity.class, EntityDataSerializers.BOOLEAN);
     private static final EntityDataAccessor<Optional<UUID>> PLAYER = SynchedEntityData.defineId(CindershellEntity.class, EntityDataSerializers.OPTIONAL_UUID);
 
-    private static final Ingredient TEMPTATION_ITEMS = Ingredient.of(Items.CRIMSON_FUNGUS, Items.WARPED_FUNGUS);
     private final UUID healthReductionUUID = UUID.fromString("189faad9-35de-4e15-a598-82d147b996d7");
     private final AnimationFactory factory = new AnimationFactory(this);
     protected CinderFurnaceContainer inventory;
@@ -225,7 +226,7 @@ public class CindershellEntity extends Animal implements IAnimatable, Bucketable
         this.goalSelector.addGoal(0, new CindershellFloatGoal(this));
         this.goalSelector.addGoal(1, new PanicGoal(this, 1.25D));
         this.goalSelector.addGoal(2, new CindershellBreedGoal(this, 1.0D));
-        this.goalSelector.addGoal(3, new TemptGoal(this, 1.0D, TEMPTATION_ITEMS, false));
+        this.goalSelector.addGoal(3, new TemptGoal(this, 1.0D, Ingredient.of(CINDERSHELL_FOOD), false));
         this.goalSelector.addGoal(4, new WaterAvoidingRandomStrollGoal(this, 1.0D));
         this.goalSelector.addGoal(5, new LookAtPlayerGoal(this, Player.class, 6.0F));
         this.goalSelector.addGoal(6, new RandomLookAroundGoal(this));
@@ -330,7 +331,7 @@ public class CindershellEntity extends Animal implements IAnimatable, Bucketable
 
     @Override
     public boolean isFood(ItemStack stack) {
-        return TEMPTATION_ITEMS.test(stack);
+        return Ingredient.of(CINDERSHELL_FOOD).test(stack);
     }
 
     public InteractionResult tryStartEat(Player player, ItemStack stack) {

--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
@@ -1,10 +1,7 @@
 package com.cgessinger.creaturesandbeasts.entities;
 
 import com.cgessinger.creaturesandbeasts.containers.CinderFurnaceContainer;
-import com.cgessinger.creaturesandbeasts.init.CNBBlocks;
-import com.cgessinger.creaturesandbeasts.init.CNBEntityTypes;
-import com.cgessinger.creaturesandbeasts.init.CNBItems;
-import com.cgessinger.creaturesandbeasts.init.CNBSoundEvents;
+import com.cgessinger.creaturesandbeasts.init.*;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -335,7 +332,7 @@ public class CindershellEntity extends Animal implements IAnimatable, Bucketable
     }
 
     public InteractionResult tryStartEat(Player player, ItemStack stack) {
-        if (stack.getItem() == Items.CRIMSON_FUNGUS || stack.getItem() == Items.WARPED_FUNGUS) {
+        if (stack.is(CINDERSHELL_FOOD)) {
             int i = this.getAge();
             if (!this.level.isClientSide && i == 0 && this.canFallInLove()) {
                 this.usePlayerItem(player, player.getUsedItemHand(), stack);

--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/EndWhaleEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/EndWhaleEntity.java
@@ -1,6 +1,7 @@
 package com.cgessinger.creaturesandbeasts.entities;
 
 import com.cgessinger.creaturesandbeasts.init.CNBSoundEvents;
+import com.cgessinger.creaturesandbeasts.init.CNBTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
@@ -56,6 +57,8 @@ import software.bernie.geckolib3.core.manager.AnimationFactory;
 import java.util.EnumSet;
 import java.util.Random;
 
+import static com.cgessinger.creaturesandbeasts.init.CNBTags.Items.END_WHALE_FOOD;
+
 public class EndWhaleEntity extends TamableAnimal implements FlyingAnimal, Saddleable, IAnimatable {
     private static final EntityDataAccessor<Boolean> SADDLED = SynchedEntityData.defineId(EndWhaleEntity.class, EntityDataSerializers.BOOLEAN);
 
@@ -77,7 +80,7 @@ public class EndWhaleEntity extends TamableAnimal implements FlyingAnimal, Saddl
     }
 
     protected void registerGoals() {
-        this.goalSelector.addGoal(0, new EndWhaleTemptGoal(this, 1.25D, Ingredient.of(Items.CHORUS_FRUIT)));
+        this.goalSelector.addGoal(0, new EndWhaleTemptGoal(this, 1.25D, Ingredient.of(END_WHALE_FOOD)));
         this.goalSelector.addGoal(1, new EndWhaleWanderGoal(this));
     }
 
@@ -291,7 +294,7 @@ public class EndWhaleEntity extends TamableAnimal implements FlyingAnimal, Saddl
     public InteractionResult mobInteract(Player player, InteractionHand hand) {
         ItemStack itemstack = player.getItemInHand(hand);
         if (this.level.isClientSide) {
-            boolean flag = this.isOwnedBy(player) || this.isTame() || itemstack.is(Items.CHORUS_FRUIT) && !this.isTame();
+            boolean flag = this.isOwnedBy(player) || this.isTame() || itemstack.is(END_WHALE_FOOD) && !this.isTame();
             return flag ? InteractionResult.CONSUME : InteractionResult.PASS;
         } else if (this.isSaddled() && player.isSecondaryUseActive()) {
             this.removeSaddle();
@@ -300,7 +303,7 @@ public class EndWhaleEntity extends TamableAnimal implements FlyingAnimal, Saddl
             this.mountWhale(player);
             return InteractionResult.sidedSuccess(this.level.isClientSide);
         } else if (!this.isTame()) {
-            if (itemstack.is(Items.CHORUS_FRUIT)) {
+            if (itemstack.is(END_WHALE_FOOD)) {
                 if (!player.getAbilities().instabuild) {
                     itemstack.shrink(1);
                 }

--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/LittleGrebeEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/LittleGrebeEntity.java
@@ -59,8 +59,9 @@ import javax.annotation.Nullable;
 import java.util.Random;
 import java.util.UUID;
 
+import static com.cgessinger.creaturesandbeasts.init.CNBTags.Items.LITTLE_GREBE_FOOD;
+
 public class LittleGrebeEntity extends Animal implements IAnimatable {
-    public static final Ingredient TEMPTATION_ITEMS = Ingredient.of(Items.COD, Items.SALMON, Items.TROPICAL_FISH);
     private static final EntityDataAccessor<BlockPos> TRAVEL_POS = SynchedEntityData.defineId(LittleGrebeEntity.class, EntityDataSerializers.BLOCK_POS);
     private final UUID healthReductionUUID = UUID.fromString("189faad9-35de-4e15-a598-82d147b996d7");
     public float flapSpeed;
@@ -84,7 +85,7 @@ public class LittleGrebeEntity extends Animal implements IAnimatable {
         this.goalSelector.addGoal(1, new MountAdultGoal(this, 1.2D));
         this.goalSelector.addGoal(2, new SmoothSwimGoal(this));
         this.goalSelector.addGoal(3, new PanicGoal(this, 1.0D));
-        this.goalSelector.addGoal(3, new TemptGoal(this, 1.0D, TEMPTATION_ITEMS, false));
+        this.goalSelector.addGoal(3, new TemptGoal(this, 1.0D, Ingredient.of(LITTLE_GREBE_FOOD), false));
         this.goalSelector.addGoal(4, new BreedGoal(this, 1.0D));
         this.goalSelector.addGoal(5, new FollowParentGoal(this, 1.25D));
         this.goalSelector.addGoal(5, new LittleGrebeEntity.SwimTravelGoal(this, 1.0D));
@@ -207,7 +208,7 @@ public class LittleGrebeEntity extends Animal implements IAnimatable {
 
     @Override
     public boolean isFood(ItemStack stack) {
-        return TEMPTATION_ITEMS.test(stack);
+        return Ingredient.of(LITTLE_GREBE_FOOD).test(stack);
     }
 
     @Override

--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/SporelingEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/SporelingEntity.java
@@ -69,6 +69,7 @@ import software.bernie.geckolib3.core.manager.AnimationFactory;
 import javax.annotation.Nullable;
 import java.util.Random;
 
+import static com.cgessinger.creaturesandbeasts.init.CNBTags.Items.SPORELING_FOOD;
 import static com.cgessinger.creaturesandbeasts.util.SporelingType.SporelingHostility.FRIENDLY;
 import static com.cgessinger.creaturesandbeasts.util.SporelingType.SporelingHostility.HOSTILE;
 import static com.cgessinger.creaturesandbeasts.util.SporelingType.SporelingHostility.NEUTRAL;
@@ -83,7 +84,7 @@ public class SporelingEntity extends TamableAnimal implements IAnimatable {
     private final NearestAttackableTargetGoal<Player> nearestAttackableTargetGoal = new NearestAttackableTargetGoal<>(this, Player.class, true);
     private final HurtByTargetGoal hurtByTargetGoal = new HurtByTargetGoal(this);
     private final WaveGoal waveGoal = new WaveGoal(this, Player.class, 8.0F);
-    private final TemptGoal temptGoal = new SporelingTemptGoal(this, 1.0D,Ingredient.of(Items.BONE_MEAL), false);
+    private final TemptGoal temptGoal = new SporelingTemptGoal(this, 1.0D, Ingredient.of(SPORELING_FOOD), false);
     private final PanicGoal panicGoal = new PanicGoal(this, 1.25D);
     private final ConvertItemGoal convertItemGoal = new ConvertItemGoal(this, 16.0D, 1.3D);
 

--- a/src/main/java/com/cgessinger/creaturesandbeasts/init/CNBTags.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/init/CNBTags.java
@@ -10,6 +10,10 @@ public class CNBTags {
     public static class Items {
         public static final TagKey<Item> MINIPAD_FLOWERS = tag("minipad_flowers");
         public static final TagKey<Item> GLOWING_MINIPAD_FLOWERS = tag("glowing_minipad_flowers");
+        public static final TagKey<Item> CINDERSHELL_FOOD = tag("cindershell_food");
+        public static final TagKey<Item> END_WHALE_FOOD = tag("end_whale_food");
+        public static final TagKey<Item> LITTLE_GREBE_FOOD = tag("little_grebe_food");
+        public static final TagKey<Item> SPORELING_FOOD = tag("sporeling_food");
 
         private static TagKey<Item> tag(String name) {
             return ItemTags.create(new ResourceLocation(CreaturesAndBeasts.MOD_ID, name));

--- a/src/main/resources/data/cnb/tags/items/cindershell_food.json
+++ b/src/main/resources/data/cnb/tags/items/cindershell_food.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:crimson_fungus",
+    "minecraft:warped_fungus"
+  ]
+}

--- a/src/main/resources/data/cnb/tags/items/end_whale_food.json
+++ b/src/main/resources/data/cnb/tags/items/end_whale_food.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:chorus_fruit"
+  ]
+}

--- a/src/main/resources/data/cnb/tags/items/little_grebe_food.json
+++ b/src/main/resources/data/cnb/tags/items/little_grebe_food.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:cod",
+    "minecraft:salmon",
+    "minecraft:tropical_fish"
+  ]
+}

--- a/src/main/resources/data/cnb/tags/items/sporeling_food.json
+++ b/src/main/resources/data/cnb/tags/items/sporeling_food.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bone_meal"
+  ]
+}


### PR DESCRIPTION
Made all breed/tame items rely on tags instead of hard-coded items because I wanna be able to tame my end whales with bolloom fruit in my modpack, this feature will probably be useful for others too.

Using the same format as vanilla's "minecraft:fox_food" tag:
"cnb:cindershell_food"
"cnb:end_whale_food"
"cnb:little_grebe_food"
"cnb:sporeling_food"

If you want me to make another couple pull requests for 1.16 and 1.19 versions too please let me know.

Pliz accept my pull request :pleading_face: 