### PR TITLE
Fixed end whale and cindershell spawns

### DIFF
--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
@@ -754,11 +754,6 @@ public class CindershellEntity extends Animal implements IAnimatable, Bucketable
     }
 
     @Override
-    public boolean removeWhenFarAway(double distanceToClosestPlayer) {
-        return !this.hasFurnace() && !this.hasCustomName();
-    }
-
-    @Override
     public boolean causeFallDamage(float distance, float damageMultiplier, DamageSource source) {
         return false;
     }

--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/CindershellEntity.java
@@ -755,7 +755,7 @@ public class CindershellEntity extends Animal implements IAnimatable, Bucketable
 
     @Override
     public boolean removeWhenFarAway(double distanceToClosestPlayer) {
-        return distanceToClosestPlayer > 256 && !this.hasFurnace() && !this.hasCustomName();
+        return !this.hasFurnace() && !this.hasCustomName();
     }
 
     @Override

--- a/src/main/java/com/cgessinger/creaturesandbeasts/entities/EndWhaleEntity.java
+++ b/src/main/java/com/cgessinger/creaturesandbeasts/entities/EndWhaleEntity.java
@@ -347,7 +347,7 @@ public class EndWhaleEntity extends TamableAnimal implements FlyingAnimal, Saddl
     }
 
     public static boolean checkEndWhaleSpawnRules(EntityType<EndWhaleEntity> animal, LevelAccessor worldIn, MobSpawnType reason, BlockPos pos, RandomSource randomIn) {
-        return true;
+        return pos.getY() >= 50;
     }
 
     @Override

--- a/src/main/resources/data/cnb/forge/biome_modifier/add_cindershell_spawns.json
+++ b/src/main/resources/data/cnb/forge/biome_modifier/add_cindershell_spawns.json
@@ -4,8 +4,8 @@
   "spawns": [
     {
       "biomes": "minecraft:nether_wastes",
-      "category": "monster",
-      "weight": 20,
+      "category": "creature",
+      "weight": 400,
       "min": 2,
       "max": 8,
       "cost": 0.0,

--- a/src/main/resources/data/cnb/forge/biome_modifier/add_cindershell_spawns.json
+++ b/src/main/resources/data/cnb/forge/biome_modifier/add_cindershell_spawns.json
@@ -4,8 +4,8 @@
   "spawns": [
     {
       "biomes": "minecraft:nether_wastes",
-      "category": "creature",
-      "weight": 400,
+      "category": "monster",
+      "weight": 20,
       "min": 2,
       "max": 8,
       "cost": 0.0,

--- a/src/main/resources/data/cnb/forge/biome_modifier/add_end_whale_spawns.json
+++ b/src/main/resources/data/cnb/forge/biome_modifier/add_end_whale_spawns.json
@@ -3,7 +3,12 @@
   "entityType": "cnb:end_whale",
   "spawns": [
     {
-      "biomes": "#forge:is_end",
+      "biomes": [
+        "minecraft:end_highlands",
+        "minecraft:end_midlands",
+        "minecraft:small_end_islands",
+        "minecraft:end_barrens"
+      ],
       "category": "creature",
       "weight": 1,
       "min": 1,


### PR DESCRIPTION
- for end whales the forge tag "is_end" doesnt seem to be available in the current version resulting in no spawns at all
- for cindershells the mob category was set to creature which made them spawn on chunk generation instead of natural spawns, which could be so far away from the player that they often get removed immedietly
EDIT: for cindershells the spawn category now stays as creature and instead they dont override removeWhenFarAway